### PR TITLE
Refactor JsonEquals

### DIFF
--- a/V.Udodov.Json.Tests/AssertionExtensions.cs
+++ b/V.Udodov.Json.Tests/AssertionExtensions.cs
@@ -1,3 +1,4 @@
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace V.Udodov.Json.Tests
@@ -6,39 +7,10 @@ namespace V.Udodov.Json.Tests
     {
         public static void JsonEquals(this string actual, string expected)
         {
-            int actualIndex = 0, expectedIndex = 0;
+            var o1 = JObject.Parse(actual);
+            var o2 = JObject.Parse(expected);
 
-            while (actualIndex < actual.Length && expectedIndex < expected.Length)
-            {
-                while (actualIndex < actual.Length && !IsValidChar(actual[actualIndex])) actualIndex++;
-                while (expectedIndex < expected.Length && !IsValidChar(expected[expectedIndex])) expectedIndex++;
-
-                Assert.True(
-                    actualIndex < actual.Length && expectedIndex < expected.Length,
-                    "JSON should have same length");
-                Assert.True(
-                    actual[actualIndex] == expected[expectedIndex],
-                    $"JSON not matching from {actual.Substring(actualIndex)} and {expected.Substring(expectedIndex)}");
-
-                actualIndex++;
-                expectedIndex++;
-            }
-
-            Assert.True(
-                actualIndex == actual.Length && expectedIndex == expected.Length,
-                "JSON should have same length");
-
-            bool IsValidChar(char c) =>
-                c >= '0' && c <= '9' ||
-                c >= 'A' && c <= 'Z' ||
-                c >= 'a' && c <= 'z' ||
-                c == '{' || c == '}' ||
-                c == '_' || c == '\'' ||
-                c == '\"' || c == '$' ||
-                c == '+' || c == '-' ||
-                c == ',' || c == '.' ||
-                c == ']' || c == '[' ||
-                c == ':';
+            Assert.True(JToken.DeepEquals(o1, o2), "JSON are not deeply equal");
         }
     }
 }


### PR DESCRIPTION
All existing tests pass:
![image](https://user-images.githubusercontent.com/12162453/63821888-f4710800-c991-11e9-9d04-72c200e603f5.png)

If I play with the json strings by adding extra spaces or formatting changes, or change the order of properties, the tests still pass.