### PR TITLE
Update Newtonsoft reference

### DIFF
--- a/V.Udodov.Json.Tests/V.Udodov.Json.Tests.csproj
+++ b/V.Udodov.Json.Tests/V.Udodov.Json.Tests.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="5.7.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-        <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.11" />
+        <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.12-beta1" />
         <PackageReference Include="xunit" Version="2.4.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     </ItemGroup>

--- a/V.Udodov.Json/V.Udodov.Json.csproj
+++ b/V.Udodov.Json/V.Udodov.Json.csproj
@@ -14,7 +14,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.11" />
+      <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.12-beta1" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Update Newtonsoft reference to use latest pre-release, which includes a fix for dependency serialization.